### PR TITLE
feat: allow filter by obtainable game

### DIFF
--- a/packages/database/repositories/pokemon/index.ts
+++ b/packages/database/repositories/pokemon/index.ts
@@ -34,6 +34,7 @@ export const getPokemonSearchIndex = createMemoizedCallback((): PokemonEntrySear
     ['base', (pk: PokemonEntry) => [pk.form.baseSpecies || pk.id]],
     ['color', (pk: PokemonEntry) => [pk.color || '']],
     ['id', (pk: PokemonEntry) => [pk.id || '']],
+    ['obtainable', (pk: PokemonEntry) => pk.location.obtainableIn],
   ])
 
   return index


### PR DESCRIPTION
Now you can use `obtainable:x` to filter Pokedex by obtainable in the x game, for example!

Helpful in analysing the best game to get missing Pokemon!